### PR TITLE
Missing Threat Intelligency Plugin

### DIFF
--- a/Docker/graylog/Dockerfile
+++ b/Docker/graylog/Dockerfile
@@ -1,4 +1,4 @@
-FROM graylog/graylog:3.1
+FROM graylog/graylog:3.1.3
 # Probably a bad idea, but it works for now
 USER root
 RUN mkdir -pv /etc/graylog/server/


### PR DESCRIPTION
Based on the error recevied while importing the content pack, it seems that graylog packaged the wrong version of the plugin jars.

FROM graylog/graylog:3.1.3